### PR TITLE
Add the ability to specify a local or remote requirements file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,6 @@ install_requires =
 [options.entry_points]
 tox =
     pypi-filter = tox_pypi_filter.plugin
+
+[isort]
+length_sort_stdlib = True


### PR DESCRIPTION
This allows specification of pins as a requirements file, which can optionally be a URL for a centralised set of pinnings